### PR TITLE
Correct compiler errors after advanced commit

### DIFF
--- a/admp_ieee80211_if.c
+++ b/admp_ieee80211_if.c
@@ -12,6 +12,7 @@
 
 #include "admp_ieee80211_if.h"
 #include "admp_err.h"
+#include "admp_utils.h"
 
 /* prv_ieee80211_ioctl_if: do ioctl of given (network interface) name */
 admp_res_t prv_ieee80211_ioctl_if(const int fd,
@@ -162,13 +163,13 @@ admp_res_t admp_ieee80211_if_init(const char *name,
 	    puts("Interface is not in monitor mode..");
 	    puts("Changing it to monitor mode..");
 
-	    res = ieee80211_set_if_mode(info,
-					IW_MODE_MONITOR);
+	    res = prv_ieee80211_set_if_mode(info,
+					    IW_MODE_MONITOR);
 	    if (res != ADMP_SUCCESS)
 		goto CLOSE_AND_OUT;
 	}
     } else {
-	res = ieee80211_set_if_mode(info, mode);
+	res = prv_ieee80211_set_if_mode(info, mode);
 	if (res != ADMP_SUCCESS)
 	    goto CLOSE_AND_OUT;
     }

--- a/admp_putils.c
+++ b/admp_putils.c
@@ -150,7 +150,7 @@ static admp_res_t prv_ieee80211_mgmt_parser(void *buff,
 	res = prv_ieee80211_beacon_parser(frame, len, ap);
 	break;
     default:
-	res = -ADMP_ERR_INVALID_FRAME;
+	res = -ADMP_ERR_UNKOWN_FRAME;
 	break;
     }
     return res;
@@ -182,7 +182,7 @@ static admp_res_t prv_ieee80211_parser(void *buff,
 	/* Data frame */
 	break;
     default:
-	res = -ADMP_ERR_INVALID_FRAME;
+	res = -ADMP_ERR_UNKOWN_FRAME;
 	break;
     }
     return res;


### PR DESCRIPTION
Correct following compiler errors:
    - Implicit function definition and function defined but not used
    - Undeclared macro

The first error is due to prv_ieee80211_set_if_mode function. This function's name is changed but the caller that calls this function, still used a old name.
The second error is due to ADMP_ERR_UNKNOWN_FRAME enum value. This value name is changed to UNKNOWN but in putils code, there are some code that using INVALID.