### PR TITLE
Correct still occurring compiler errors

### DIFF
--- a/admp_ieee80211_if.c
+++ b/admp_ieee80211_if.c
@@ -203,7 +203,7 @@ admp_res_t admp_ieee80211_if_destroy(struct admp_ieee80211_if_info *info)
 	 * Setting interface mode to a previous mode may fail but in this phase,
 	 * this is not an fatal error. So just move on.
 	 */
-	ieee80211_set_if_mode(info, &ifr, &iwr, info->prev_mode);
+	prv_ieee80211_set_if_mode(info, &ifr, &iwr, info->prev_mode);
     }
 
     if (close(info->fd) == -1) {

--- a/admp_putils.c
+++ b/admp_putils.c
@@ -150,7 +150,7 @@ static admp_res_t prv_ieee80211_mgmt_parser(void *buff,
 	res = prv_ieee80211_beacon_parser(frame, len, ap);
 	break;
     default:
-	res = -ADMP_ERR_UNKOWN_FRAME;
+	res = -ADMP_ERR_UNKNOWN_FRAME;
 	break;
     }
     return res;
@@ -182,7 +182,7 @@ static admp_res_t prv_ieee80211_parser(void *buff,
 	/* Data frame */
 	break;
     default:
-	res = -ADMP_ERR_UNKOWN_FRAME;
+	res = -ADMP_ERR_UNKNOWN_FRAME;
 	break;
     }
     return res;


### PR DESCRIPTION
Still some codes use old function names like ieee80211_set_if_mode and there are terrible typos in the putils code!!