### PR TITLE
Dev: original source files are seperated to related directories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,16 @@
+# Makefile
+
+SUBDIRS = wlt main
+OBJDIR = ./obj
+EXENAME = ./bin/wltool
+
+.PHONY: subdirs $(SUBDIRS)
+
+subdirs: $(SUBDIRS)
+
+$(SUBDIRS):
+	$(MAKE) -C $@
+
+clean:
+	rm -f $(OBJDIR)/*.o $(EXENAME)
+

--- a/include/ll.h
+++ b/include/ll.h
@@ -1,0 +1,21 @@
+#ifndef __LL_H__
+#define __LL_H__
+
+#include <stddef.h>
+
+struct ll_node {
+    struct ll_node *next;
+};
+
+struct ll_list {
+    struct ll_link *head;
+    size_t dataoff;
+
+    int (*compare)(void *, void *); /* shall return -1 or 0 or 1 */
+    int (*getdata)(void *);
+};
+
+struct ll_list *ll_list_init(size_t dataoff, size_t datasize);
+void ll_list_destroy(struct ll_list *list);
+
+#endif

--- a/include/wlt.h
+++ b/include/wlt.h
@@ -1,0 +1,22 @@
+#ifndef __WLT_H__
+#define __WLT_H__
+
+#include <stdint.h>
+#include <linux/wireless.h>
+
+/* Structure for wireless device in Wireless Tools */
+struct wlt_dev {
+    int sockfd;			/* socket for wireless device */
+    int index;
+    uint32_t prevmode;		/* initial mode of wireless device */
+    uint32_t mode;		/* changed mode by the program */
+    char name[IFNAMSIZ + 1];	/* wireless device name */
+    int32_t chann;		/* current channel of wireless device */
+};
+
+struct wlt_dev *wlt_init(char *name);
+void wlt_destroy(struct wlt_dev *wdev);
+
+#include "wlt_ieee80211_pcap.h"
+
+#endif

--- a/include/wlt_ieee80211_ap.h
+++ b/include/wlt_ieee80211_ap.h
@@ -1,0 +1,20 @@
+#ifndef __WLT_IEEE80211_AP_H__
+#define __WLT_IEEE80211_AP_H__
+
+#include <stdint.h>
+#include "ll.h"
+
+#define WLT_IEEE80211_APNAMSIZ 32
+
+struct wlt_ieee80211_ap {
+    int8_t antsig;
+    uint8_t bssid[7];		/* 6th byte to check bssid is not NULL */
+    char ssid[WLT_IEEE80211_APNAMSIZ];
+
+    struct ll_node link;
+};
+
+struct wlt_ieee80211_ap *wlt_ieee80211_ap_init(void);
+void wlt_ieee80211_ap_destroy(struct wlt_ieee80211_ap *ap);
+
+#endif

--- a/include/wlt_ieee80211_pcap.h
+++ b/include/wlt_ieee80211_pcap.h
@@ -1,0 +1,93 @@
+#ifndef __WLT_IEEE80211_PCAP__
+#define __WLT_IEEE80211_PCAP__
+
+#include <stdio.h>
+#include <stdint.h>
+
+struct wlt_ieee80211_radiotap_hdr {
+    uint8_t ver;		/* Version */
+    uint8_t pad;		/* Padding */
+    uint16_t len;		/* Length */
+    uint32_t present;
+    uint8_t variable[];
+} __attribute__((__packed__));
+
+#define WLT_IS_RADIOTAP_PRESENCE_EXTENDED(present) \
+    (((present) >> 31) & 1)
+
+#define WLT_RADIOTAP_ANTSIG_BITLOC 5
+#define WLT_IS_RADIOTAP_ANTENNA_SIG_PRESENT(present) \
+    (((present) >> 5) & 1)
+
+struct wlt_ieee80211_frm_ctl {
+    uint16_t proto: 2,
+	    type: 2,
+	    subtype: 4,
+	    ds: 2,		/* [tods][fromds] */
+	    moreflag: 1,
+	    retry: 1,
+	    pwrmgmt: 1,
+	    moredata: 1,
+	    wep: 1,
+	    order: 1;
+} __attribute__((__packed__));
+
+struct wlt_ieee80211_seq_ctl {
+    uint16_t fragnum: 4,
+	    seqnum: 12;
+} __attribute__((__packed__));
+
+/*
+ * This header structure is for generic case. But in IEEE 802.11,
+ * header structure varies by frame categories.
+ */
+struct wlt_ieee80211_mac_frm {
+    struct wlt_ieee80211_frm_ctl fc;
+    uint16_t durid;		/* Duration / ID */
+    uint8_t addr1[6];
+    uint8_t addr2[6];
+    uint8_t addr3[6];
+    struct wlt_ieee80211_seq_ctl seqctl;
+    uint8_t addr4[6];
+    uint8_t variable[];
+} __attribute__((__packed__));
+
+struct wlt_ieee80211_mac_trailer {
+    uint32_t fcs;
+} __attribute__((__packed__));
+
+struct wlt_ieee80211_mgmt_frm {
+    /* header */
+    struct wlt_ieee80211_frm_ctl fc;
+    uint16_t durid;
+    uint8_t addr1[6];
+    uint8_t addr2[6];
+    uint8_t addr3[6];
+    struct wlt_ieee80211_seq_ctl seqctl;
+    uint8_t variable[];
+} __attribute__((__packed__));
+
+struct wlt_ieee80211_beacon {
+    uint64_t tmstamp;		/* Timestamp */
+    uint16_t interval;		/* Beacon interval */
+    uint16_t capinfo;		/* Capability information */
+    uint8_t variable[];		/* Information Elements */
+} __attribute__((__packed__));
+
+struct wlt_ieee80211_assoc_req {
+    uint16_t capinfo;		/* Capability information */
+    uint16_t interval;		/* Listening interval */
+    uint8_t variable[];		/* Information Elements */
+} __attribute__((__packed__));
+
+struct wlt_ieee80211_tld {
+    uint8_t type;		/* EID */
+    uint8_t len;		/* Length */
+    uint8_t data[];		/* Data */
+} __attribute__((__packed__));
+
+#define WLT_IEEE80211_BUFSIZ 4096
+
+int wlt_ieee80211_pcap(struct wlt_dev *wdev);
+
+#endif

--- a/include/wlt_ioctl.h
+++ b/include/wlt_ioctl.h
@@ -1,0 +1,19 @@
+#ifndef __WLT_IOCTL_H__
+#define __WLT_IOCTL_H__
+
+int wlt_getindex(struct wlt_dev *wdev);
+int wlt_getmode(struct wlt_dev *wdev);
+int wlt_setmode(struct wlt_dev *wdev, const uint32_t mode);
+int wlt_setchann(struct wlt_dev *wdev, int chann);
+
+/* IEEE 802.11 2.4GHz macros */
+#define WLT_IEEE80211_24_BASE_FREQ 2407
+#define WLT_IEEE80211_24_FREQ_INTERVAL 5
+#define WLT_IEEE80211_24_FREQ2CHANN(freq) \
+    (((freq) - WLT_IEEE80211_24_BASE_FREQ) / WLT_IEEE80211_24_FREQ_INTERVAL)
+#define WLT_IEEE80211_24_CHANN2FREQ_M(chann) \
+    (((chann) * WLT_IEEE80211_24_FREQ_INTERVAL + WLT_IEEE80211_24_BASE_FREQ) \
+     * 100000)
+#define WLT_IEEE80211_24_HOP_CHANN(currchan) (((currchan) + 1) % 13 + 1)
+
+#endif

--- a/main/Makefile
+++ b/main/Makefile
@@ -1,0 +1,16 @@
+# Makefile
+
+CC = gcc
+CFLAGS = --std=c99 -Wall -I../include
+EXENAME = wltool
+BINDIR = ../bin
+SOURCES := main.c
+OBJDIR = ../obj
+OBJS := $(addprefix $(OBJDIR)/, ${SOURCES:.c=.o})
+
+all: ${OBJS}
+	@ mkdir -p $(BINDIR)
+	$(CC) $(OBJDIR)/*.o -o $(BINDIR)/$(EXENAME)
+
+$(OBJDIR)/%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@

--- a/main/main.c
+++ b/main/main.c
@@ -1,0 +1,22 @@
+#include <stdio.h>
+#include "wlt.h"
+
+int main(int argc, char *argv[])
+{
+    struct wlt_dev *wdev;
+
+    if (argc < 3) {
+	fputs("Usage: %s [-c] <interface name>\n", stderr);
+	return -1;
+    }
+    
+    wdev = wlt_init(argv[2]);
+    if (wdev == NULL)
+	return -1;
+
+    wlt_ieee80211_pcap(wdev);
+
+    puts("destroying wlt..");
+    wlt_destroy(wdev);
+    return 0;
+}

--- a/wlt/Makefile
+++ b/wlt/Makefile
@@ -1,0 +1,13 @@
+# Makefile
+
+CC = gcc
+CFLAGS = --std=c99 -Wall -I../include
+OBJDIR := ../obj
+SOURCES := $(wildcard ./*.c)
+OBJS := $(addprefix $(OBJDIR)/, ${SOURCES:.c=.o})
+
+all: ${OBJS}
+
+$(OBJDIR)/%.o: %.c
+	@ mkdir -p $(OBJDIR)
+	$(CC) $(CFLAGS) -c $< -o $@

--- a/wlt/wlt.c
+++ b/wlt/wlt.c
@@ -1,0 +1,60 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <linux/if_packet.h>
+#include <net/ethernet.h>
+#include <linux/wireless.h>
+#include "wlt.h"
+#include "wlt_ioctl.h"
+
+struct wlt_dev *wlt_init(char *name)
+{
+    struct wlt_dev *wdev;
+
+    if (name == NULL)
+	return NULL;
+
+    wdev = malloc(sizeof(*wdev));
+    if (wdev == NULL) {
+	perror("malloc");
+	return NULL;
+    }
+
+    wdev->sockfd = socket(AF_PACKET, SOCK_RAW, htons(ETH_P_ALL));
+    if (wdev->sockfd == -1) {
+	perror("socket");
+	free(wdev);
+	return NULL;
+    }
+
+    strncpy(wdev->name, name, IFNAMSIZ);
+
+    if (wlt_getindex(wdev) == -1) {
+	close(wdev->sockfd);
+	free(wdev);
+	return NULL;
+    }
+
+    if (wlt_getmode(wdev) == -1) {
+	close(wdev->sockfd);
+	free(wdev);
+	return NULL;
+    }
+
+    /*
+     * In initially plugged state, ioctl prints error while getting
+     * channel.
+     */
+    wdev->chann = 1;
+    return wdev;
+}
+
+void wlt_destroy(struct wlt_dev *wdev)
+{
+    close(wdev->sockfd);
+    memset(wdev, 0x00, sizeof(*wdev));
+    free(wdev);
+}

--- a/wlt/wlt_ieee80211_ap.c
+++ b/wlt/wlt_ieee80211_ap.c
@@ -1,0 +1,21 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include "wlt_ieee80211_ap.h"
+
+struct wlt_ieee80211_ap *wlt_ieee80211_ap_init(void)
+{
+    struct wlt_ieee80211_ap *ap;
+
+    ap = malloc(sizeof(*ap));
+    if (ap == NULL) {
+	perror("malloc");
+	return NULL;
+    }
+    ap->link.next = NULL;
+    return ap;
+}
+
+void wlt_ieee80211_ap_destroy(struct wlt_ieee80211_ap *ap)
+{
+    free(ap);
+}

--- a/wlt/wlt_ieee80211_pcap.c
+++ b/wlt/wlt_ieee80211_pcap.c
@@ -1,0 +1,361 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <setjmp.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/epoll.h>
+#include <linux/wireless.h>
+#include "wlt.h"
+#include "wlt_ioctl.h"
+#include "wlt_ieee80211_pcap.h"
+#include "wlt_ieee80211_ap.h"
+
+#define WLT_IS_X_IN_RANGE(min, x, max) (((x) >= (min)) && ((x) < (max)))
+#define WLT_IS_X_GT_LT(min, x, max) (((x) > (min)) && ((x) < (max)))
+
+static int ___wlt_ieee80211_beacon_parser(struct wlt_ieee80211_mgmt_frm *frm,
+					  ssize_t len,
+					  struct wlt_ieee80211_ap *ap)
+{
+    int res, done;
+    struct wlt_ieee80211_beacon *bean;
+    struct wlt_ieee80211_tld *ie;
+    
+    if (frm == NULL || len < 0 || ap == NULL)
+	return -1;
+
+    bean = (struct wlt_ieee80211_beacon *) frm->variable;
+    ie = (struct wlt_ieee80211_tld *) bean->variable;
+
+    res = 0;
+    done = 0;
+    while (len > 0 && done == 0) {
+	if (!WLT_IS_X_GT_LT(0, ie->len, len)) {
+	    res = -1;
+	    break;
+	}
+
+	switch (ie->type) {
+	case 0x00:
+	    /* SSID */
+	    strncpy(ap->ssid, (char *) ie->data, ie->len);
+	    done = 1;
+	    break;
+	default:
+	    done = 1;
+	    break;
+	}
+
+	ie = (struct wlt_ieee80211_tld *) ((uint8_t *) ie + ie->len);
+	len -= ie->len;
+    }
+    return res;
+}
+
+static int
+___wlt_ieee80211_assoc_req_parser(struct wlt_ieee80211_mgmt_frm *frm,
+				  ssize_t len,
+				  struct wlt_ieee80211_ap *ap)
+{
+    int res, done;
+    struct wlt_ieee80211_assoc_req *assoc_req;
+    struct wlt_ieee80211_tld *ie;
+
+    if (frm == NULL || len < 0 || ap == NULL)
+	return -1;
+
+    assoc_req = (struct wlt_ieee80211_assoc_req *) frm->variable;
+    ie = (struct wlt_ieee80211_tld *) assoc_req->variable;
+
+    done = 0;
+    res = 0;
+    while (len > 0 && done == 0) {
+	if (!WLT_IS_X_GT_LT(0, ie->len, len)) {
+	    res = -1;
+	    break;
+	}
+
+	switch (ie->type) {
+	case 0x00:
+	    /* SSID */
+	    strncpy(ap->ssid, (char *) ie->data, ie->len);
+	    done = 1;
+	    break;
+	default:
+	    done = 1;
+	    break;
+	}
+
+	ie = (struct wlt_ieee80211_tld *) ((uint8_t *) ie + ie->len);
+	len -= ie->len;
+    }
+    return res;
+}
+
+static int __wlt_ieee80211_mgmt_parser(void *buff,
+				       ssize_t len,
+				       struct wlt_ieee80211_ap *ap)
+{
+    int res;
+    struct wlt_ieee80211_mgmt_frm *frm;
+    uint8_t *bssid;
+
+    if (buff == NULL || len < 0 || ap == NULL)
+	return -1;
+
+    frm = buff;
+    switch (frm->fc.ds) {
+    case 0b00:
+	/* IBSS or BSS */
+	bssid = frm->addr3;
+	break;
+    case 0b01:
+	/* From AP */
+	bssid = frm->addr2;
+	break;
+    case 0b10:
+	/* To AP */
+	bssid = frm->addr1;
+	break;
+    case 0b11:
+	/* Wireless bridge */
+	bssid = NULL;
+	break;
+    default:
+	bssid = NULL;
+	break;
+    }
+
+    if (bssid) {
+	memcpy(ap->bssid, bssid, 6);
+	ap->bssid[6] = !0;
+    } else {
+	memset(ap->bssid, 0x00, 7);
+    }
+
+    switch (frm->fc.subtype) {
+    case 0b0000:
+	/* Association request frame */
+	/* puts("assoc"); */
+	res = ___wlt_ieee80211_assoc_req_parser(frm, len, ap);
+	break;
+    case 0b1000:
+	/* Beacon frame */
+	res = ___wlt_ieee80211_beacon_parser(frm, len, ap);
+	break;
+    default:
+	res = -1;
+	break;
+    }
+    return res;
+}
+
+static int __wlt_ieee80211_mac_parser(void *buff,
+				      ssize_t len,
+				      struct wlt_ieee80211_ap *ap)
+{
+    int res;
+    struct wlt_ieee80211_mac_frm *frm;
+
+    if (buff == NULL || len < 0 || ap == NULL)
+	return -1;
+
+    res = -1;
+    frm = buff;
+    switch (frm->fc.type) {
+    case 0b00:
+	/* Management frame */
+	res = __wlt_ieee80211_mgmt_parser(buff, len, ap);
+	break;
+    case 0b01:
+	/* Control frame */
+	break;
+    case 0b10:
+	/* Data frame */
+	break;
+    default:
+	res = -1;
+	break;
+    }
+    return res;
+}
+
+static int ___wlt_ieee80211_radiotap_off(uint64_t present, unsigned int bitloc)
+{
+    unsigned int offtab[] = {
+	sizeof(uint64_t),	/* TSFT */
+	sizeof(uint8_t),	/* Flags */
+	sizeof(uint8_t),	/* Rate */
+	sizeof(uint16_t),	/* Channel */
+	sizeof(uint8_t) + sizeof(uint8_t) /* hop set + hop pattern */
+
+	/* [TODO] Add defined fields */
+    };
+    unsigned int off, i;
+    uint64_t mask;
+
+    off = 0;
+    for (i = 0; i < bitloc; i++) {
+	mask = 1 << i;
+	if (mask & present)
+	    off += offtab[i];
+    }
+    return off;
+}
+
+static void *__wlt_ieee80211_radiotap_parser(void *buff,
+					     ssize_t len,
+					     struct wlt_ieee80211_ap *ap)
+{
+    int antsig_off;
+    struct wlt_ieee80211_radiotap_hdr *hdr;
+    uint8_t *data;
+
+    if (buff == NULL || len < 0)
+	return NULL;
+
+    hdr = buff;
+
+    antsig_off = ___wlt_ieee80211_radiotap_off(*((uint64_t *) &hdr->present),
+					       WLT_RADIOTAP_ANTSIG_BITLOC);
+    if (antsig_off == -1)
+	return NULL;
+
+    if (WLT_IS_RADIOTAP_PRESENCE_EXTENDED(hdr->present)) {
+	data = hdr->variable + antsig_off + sizeof(uint32_t);
+    } else {
+	data = hdr->variable + antsig_off;
+    }
+    ap->antsig = (int8_t) *data;
+    /* printf("antsig: %d\n", antsig); */
+
+    if (ap->antsig >= 0)
+	return NULL;
+    
+    if (!WLT_IS_X_IN_RANGE(0, hdr->len, len))
+	return NULL;
+    return (buff + hdr->len);
+}
+
+static int _wlt_ieee80211_parser(void *buff,
+				 ssize_t len,
+				 struct wlt_ieee80211_ap *ap)
+{
+    void *buffp;
+    
+    if (buff == NULL || len < 0)
+	return -1;
+
+    /* puts("There is a packet.."); */
+
+    buffp = __wlt_ieee80211_radiotap_parser(buff, len, ap);
+    if (buffp == NULL)
+	return -1;
+
+    if (__wlt_ieee80211_mac_parser(buffp, len, ap) == -1)
+	return -1;
+    return 0;
+}
+
+#define MAX_EVTCNT 128
+
+/* wlt_ieee80211_pcap: capture ieee80211 packets */
+int wlt_ieee80211_pcap(struct wlt_dev *wdev)
+{
+    int fdflags, epollfd, evtcnt, i;
+    int res;
+    struct epoll_event evts[2], epoll_evts[MAX_EVTCNT];
+    struct wlt_ieee80211_ap *apbuf;
+    ssize_t frmlen;
+    uint8_t buff[WLT_IEEE80211_BUFSIZ];
+
+    if (wdev == NULL)
+	return -1;
+
+    if (wdev->mode != IW_MODE_MONITOR)
+	if (wlt_setmode(wdev, IW_MODE_MONITOR) == -1)
+	    return -1;
+
+    fdflags = fcntl(wdev->sockfd, F_GETFL);
+    fdflags |= O_NONBLOCK;
+    if (fcntl(wdev->sockfd, F_SETFL, fdflags) < 0) {
+	perror("fcntl");
+	return -1;
+    }
+    
+    epollfd = epoll_create(2);
+    if (epollfd < 0) {
+	perror("epoll_create");
+	return -1;
+    }
+    
+    evts[0].events = EPOLLIN;
+    evts[0].data.fd = wdev->sockfd;
+    if (epoll_ctl(epollfd, EPOLL_CTL_ADD, wdev->sockfd, &evts[0]) < 0) {
+	perror("epoll_ctl");
+	close(epollfd);
+	return -1;
+    }
+
+    evts[1].events = EPOLLIN;
+    evts[1].data.fd = STDIN_FILENO;
+    if (epoll_ctl(epollfd, EPOLL_CTL_ADD, STDIN_FILENO, &evts[1]) < 0) {
+	perror("epoll_ctl");
+	close(epollfd);
+	return -1;
+    }
+
+    apbuf = wlt_ieee80211_ap_init();
+    if (apbuf == NULL) {
+	close(epollfd);
+	return -1;
+    }
+
+    while (1) {
+	evtcnt = epoll_wait(epollfd, epoll_evts, MAX_EVTCNT, 5000);
+	if (evtcnt < 0) {
+	    perror("epoll_wait");
+	    close(epollfd);
+	    return -1;
+	}
+
+	for (i = 0; i < evtcnt; i++) {
+	    if (epoll_evts[i].data.fd == wdev->sockfd) {
+		memset(buff, 0x00, sizeof(buff));
+		frmlen = read(wdev->sockfd, buff, WLT_IEEE80211_BUFSIZ);
+		if (frmlen >= 0) {
+		    res = _wlt_ieee80211_parser(buff, frmlen, apbuf);
+		}
+
+		if (!res) {
+		    printf("%s - %d\n", apbuf->ssid, apbuf->antsig);
+		    memset(apbuf, 0x00, sizeof(*apbuf));
+		}
+	    }
+
+	    if (epoll_evts[i].data.fd == STDIN_FILENO) {
+		/* printf("user key: %c\n", getchar()); */
+		if (getchar() == 'q')
+		    goto OUT;
+	    }
+	}
+
+	puts("channel hopping..");
+	/* printf("channel: %d\n", wdev->chann); */
+	if (wlt_setchann(wdev,
+			 WLT_IEEE80211_24_HOP_CHANN(wdev->chann)) == -1) {
+	    close(epollfd);
+	    free(apbuf);
+	    return -1;
+	}
+    }
+    
+OUT:
+    close(epollfd);
+    free(apbuf);
+    return 0;
+}

--- a/wlt/wlt_ioctl.c
+++ b/wlt/wlt_ioctl.c
@@ -1,0 +1,146 @@
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <arpa/inet.h>
+#include <linux/if_ether.h>
+#include <linux/wireless.h>
+#include "wlt.h"
+#include "wlt_ioctl.h"
+
+/* prv_wlt_ioctl_if: do ioctl of given (network interface) name */
+static int _wlt_ioctl_if(const int fd,
+			   const char *name,
+			   unsigned long req,
+			   struct ifreq *ifr)
+{
+    if (fd < 0 || name == NULL || ifr == NULL)
+	return -1;
+
+    strncpy(ifr->ifr_name, name, IFNAMSIZ);
+    if (ioctl(fd, req, ifr) == -1) {
+	perror("ioctl");
+	return -1;
+    }
+    return 0;
+}
+
+/* prv_wlt_ioctl_iw: do ioctl of given (wireless interface) name */
+static int _wlt_ioctl_iw(const int fd,
+			   const char *name,
+			   const unsigned long req,
+			   struct iwreq *iwr)
+{
+    if (fd < 0 || name == NULL || iwr == NULL)
+	return -1;
+
+    strncpy(iwr->ifr_ifrn.ifrn_name, name, IFNAMSIZ);
+    if (ioctl(fd, req, iwr) == -1) {
+	perror("ioctl");
+	return -1;
+    }
+    return 0;
+}
+
+#define WLT_GET_IW_MODE(fd, name, iwr)				\
+    _wlt_ioctl_iw((fd), (name), (SIOCGIWMODE), (iwr))
+#define WLT_GET_IW_CHANN(fd, name, iwr)				\
+    _wlt_ioctl_iw((fd), (name), (SIOCGIWFREQ), (iwr))
+#define WLT_SET_IW_MODE(fd, name, iwr)				\
+    _wlt_ioctl_iw((fd), (name), (SIOCSIWMODE), (iwr))
+#define WLT_SET_IW_CHANN(fd, name, iwr)				\
+    _wlt_ioctl_iw((fd), (name), (SIOCSIWFREQ), (iwr))
+
+#define WLT_SET_IF_FLAG(fd, name, ifr)				\
+    _wlt_ioctl_if((fd), (name), (SIOCSIFFLAGS), (ifr))
+#define WLT_GET_IF_INDEX(fd, name, ifr)				\
+    _wlt_ioctl_if((fd), (name), (SIOCGIFINDEX), (ifr))
+#define WLT_GET_IF_HWADDR(fd, name, ifr)			\
+    _wlt_ioctl_if((fd), (name), (SIOCGIFHWADDR), (ifr))
+
+int wlt_getindex(struct wlt_dev *wdev)
+{
+    struct ifreq ifr;
+    
+    if (wdev == NULL)
+	return -1;
+
+    if (WLT_GET_IF_INDEX(wdev->sockfd, wdev->name, &ifr) == -1)
+	return -1;
+    wdev->index = ifr.ifr_ifindex;
+    return 0;
+}
+
+int wlt_getmode(struct wlt_dev *wdev)
+{
+    struct iwreq iwr;
+
+    if (wdev == NULL)
+	return -1;
+
+    if (WLT_GET_IW_MODE(wdev->sockfd, wdev->name, &iwr) == -1)
+	return -1;
+    wdev->prevmode = iwr.u.mode;
+    wdev->mode = iwr.u.mode;
+    return 0;
+}
+
+int wlt_setmode(struct wlt_dev *wdev, const uint32_t mode)
+{
+    char *modes[] = {
+	"driver decided mode",
+	"single cell network",
+	"multi cell network, roaming",
+	"synchronization master or access point",
+	"wireless repeater (forwarder)",
+	"secondary master / repeater (backup)",
+	"passive monitor (listen only)",
+	"mesh (IEEE 802.11s) network"
+    };
+    int res;
+    struct ifreq ifr;
+    struct iwreq iwr;
+    
+    if (wdev == NULL)
+	return -1;
+
+    puts("Interface down..");
+    ifr.ifr_flags |= ((short) ~0) & ~IFF_UP;
+    if (WLT_SET_IF_FLAG(wdev->sockfd, wdev->name, &ifr) == -1)
+	return -1;
+
+    printf("Changing mode from %s to %s.. ", modes[wdev->prevmode],
+	   modes[mode]);
+    iwr.u.mode = mode;
+    res = WLT_SET_IW_MODE(wdev->sockfd, wdev->name, &iwr);
+    if (res == -1)
+	puts("failed");
+
+    puts("Interface up..");
+    ifr.ifr_flags |= IFF_UP;
+    if (WLT_SET_IF_FLAG(wdev->sockfd, wdev->name, &ifr) == -1)
+	return -1;
+    if (res == -1)
+	return -1;
+    wdev->mode = mode;
+    return 0;
+}
+
+int wlt_setchann(struct wlt_dev *wdev, int chann)
+{
+    struct iwreq iwr;
+    
+    if (wdev == NULL)
+	return -1;
+
+    iwr.u.freq.m = WLT_IEEE80211_24_CHANN2FREQ_M(chann);
+    iwr.u.freq.e = 1;
+    if (WLT_SET_IW_CHANN(wdev->sockfd, wdev->name, &iwr) == -1)
+	return -1;
+    wdev->chann = chann;
+    return 0;
+}


### PR DESCRIPTION
There are two major modification in this pull request: original source file seperation and channel hopping feature addition.

Since sniffed APs will be handled through data structures like linked lists, I seperated original source files to related directories. Therefore, Makefiles are modified to handle subdirectories compilation.

Channel hopping feature is added to `wlt_ieee80211_pcap()`. This feature is implemented via `epoll` because I thought I/O multiplexing is light-weighted than multi-threading or multi-processing and most suitable for this task.